### PR TITLE
Add dependencies to successfully finish Magento2 Install Process with this Module present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
     "magento/framework": "^100.1",
-    "magenerds/dashboard": "^1.0"
+    "magenerds/dashboard": "^1.0",
+    "magento/module-directory": "^1.0",
+    "magento/module-tax": "^1.0"
   },
   "repositories": {
     "magento": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,5 +18,10 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magenerds_GermanLaw" setup_version="1.0.4" />
+    <module name="Magenerds_GermanLaw" setup_version="1.0.4">
+        <sequence>
+            <module name="Magento_Directory" />
+            <module name="Magento_Tax" />
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
Magento2 Installer will install this extension before it's requirements which leads to a duplicate-key-constraint error in database.

With these Requirements Magento2 Installer will know to install Directory & Tax Modules before this one.